### PR TITLE
Fix: filter null authors from PRs and reviews

### DIFF
--- a/src/interactors/__tests__/getPulls.test.js
+++ b/src/interactors/__tests__/getPulls.test.js
@@ -6,8 +6,12 @@ jest.mock('../../parsers', () => ({ parsePullRequest: jest.fn() }));
 jest.mock('../../fetchers', () => ({ fetchPullRequests: jest.fn() }));
 
 const buildResponse = (items) => {
-  const edges = [];
-  for (let i = 0; i < items; i++) edges.push({ cursor: 'CURSOR', node: { id: i } });
+  const edges = [{ cursor: 'CURSOR', node: { id: 123, author: null } }];
+
+  for (let i = 0; i < items; i++) {
+    edges.push({ cursor: 'CURSOR', node: { id: i, author: {} } });
+  }
+
   return { search: { edges } };
 };
 

--- a/src/interactors/getPulls.js
+++ b/src/interactors/getPulls.js
@@ -1,6 +1,8 @@
 const { fetchPullRequests } = require('../fetchers');
 const { parsePullRequest } = require('../parsers');
 
+const filterNullAuthor = ({ node }) => !!node.author;
+
 const ownerFilter = ({ org, repos }) => {
   if (org) return `org:${org}`;
   return (repos || []).map((r) => `repo:${r}`).join(' ');
@@ -14,7 +16,7 @@ const buildQuery = ({ org, repos, startDate }) => {
 const getPullRequests = async (params) => {
   const { limit } = params;
   const data = await fetchPullRequests(params);
-  const results = data.search.edges.map(parsePullRequest);
+  const results = data.search.edges.filter(filterNullAuthor).map(parsePullRequest);
   if (results.length < limit) return results;
 
   const last = results[results.length - 1].cursor;

--- a/src/parsers/__tests__/mocks/pullRequest.json
+++ b/src/parsers/__tests__/mocks/pullRequest.json
@@ -40,6 +40,16 @@
             "login": "Estebes10",
             "avatarUrl": "https://avatars.githubusercontent.com/u/22161828?v=4"
           }
+        },
+        {
+          "submittedAt": "2021-02-17T13:00:22Z",
+          "commit": {
+            "pushedDate": "2021-02-16T22:39:22Z"
+          },
+          "comments": {
+            "totalCount": 9
+          },
+          "author": null
         }
       ]
     }

--- a/src/parsers/__tests__/parsePullRequest.test.js
+++ b/src/parsers/__tests__/parsePullRequest.test.js
@@ -15,5 +15,6 @@ describe('Parsers | .parsePullRequest', () => {
       avatarUrl: 'https://avatars.githubusercontent.com/u/1031639?u=30204017b73f7a1f08005cb8ead3f70b0410486c&v=4',
     });
     expect(response).toHaveProperty('reviews');
+    expect(response.reviews).toHaveLength(2);
   });
 });

--- a/src/parsers/parsePullRequest.js
+++ b/src/parsers/parsePullRequest.js
@@ -2,6 +2,10 @@ const get = require('lodash.get');
 const parseUser = require('./parseUser');
 const parseReview = require('./parseReview');
 
+const filterNullAuthor = ({ author }) => !!author;
+
+const getFilteredReviews = (data) => get(data, 'node.reviews.nodes', []).filter(filterNullAuthor);
+
 module.exports = (data = {}) => {
   const author = parseUser(get(data, 'node.author'));
   const publishedAt = new Date(get(data, 'node.publishedAt'));
@@ -12,6 +16,6 @@ module.exports = (data = {}) => {
     publishedAt,
     cursor: data.cursor,
     id: get(data, 'node.id'),
-    reviews: get(data, 'node.reviews.nodes', []).map(handleReviews),
+    reviews: getFilteredReviews(data).map(handleReviews),
   };
 };


### PR DESCRIPTION
This PR updates `getPulls` to remove pull requests authored by people who have since been removed from the org, and `parsePullRequest` to remove reviews by people who have been removed from the org. I was going to leave the `dist` build and change-log update to you, but happy to do it if you'd like!