### PR TITLE
Add column for amount of comments per review.

### DIFF
--- a/dist/index.js
+++ b/dist/index.js
@@ -433,7 +433,7 @@ module.exports = (reviews) => {
   return {
     totalReviews,
     totalComments,
-    commentsPerReview: divide(totalComments, totalReviews),
+    commentsPerReview: Math.round(divide(totalComments, totalReviews) * 10) / 10,
     timeToReview: median(getProperty(reviews, 'timeToReview')),
   };
 };
@@ -9915,6 +9915,7 @@ const getChartsData = ({ index, contributions, displayCharts }) => {
     timeStr: addBr(generateChart(contributions.timeToReview)),
     reviewsStr: addBr(generateChart(contributions.totalReviews)),
     commentsStr: addBr(generateChart(contributions.totalComments)),
+    commentsPerReviewStr: addBr(generateChart(contributions.commentsPerReview))
   };
 };
 
@@ -9966,6 +9967,7 @@ module.exports = ({
     const timeStr = addReviewsTimeLink(timeVal, disableLinks, urls.timeToReview);
     const reviewsStr = printStat(stats, 'totalReviews', noParse);
     const commentsStr = printStat(stats, 'totalComments', noParse);
+    const commentsPerReviewStr = printStat(stats, 'commentsPerReview', noParse);
 
     return {
       avatar,
@@ -9973,6 +9975,7 @@ module.exports = ({
       timeToReview: `${timeStr}${chartsData.timeStr}`,
       totalReviews: `${reviewsStr}${chartsData.reviewsStr}`,
       totalComments: `${commentsStr}${chartsData.commentsStr}`,
+      commentsPerReview: `${commentsPerReviewStr}${chartsData.commentsPerReviewStr}`,
     };
   };
 
@@ -12282,6 +12285,7 @@ const SORT_KEY = {
   TIME: 'timeToReview',
   REVIEWS: 'totalReviews',
   COMMENTS: 'totalComments',
+  COMMENTS_PER_REVIEW: 'commentsPerReview',
 };
 
 const TITLES = {
@@ -12290,9 +12294,10 @@ const TITLES = {
   timeToReview: 'Median time to review',
   totalReviews: 'Total reviews',
   totalComments: 'Total comments',
+  commentsPerReview: 'Comments / review',
 };
 
-const COLUMNS_ORDER = ['totalReviews', 'timeToReview', 'totalComments'];
+const COLUMNS_ORDER = ['totalReviews', 'timeToReview', 'totalComments', 'commentsPerReview'];
 
 const STATS_OPTIMIZATION = {
   totalReviews: 'MAX',

--- a/src/interactors/buildTable/constants.js
+++ b/src/interactors/buildTable/constants.js
@@ -2,6 +2,7 @@ const SORT_KEY = {
   TIME: 'timeToReview',
   REVIEWS: 'totalReviews',
   COMMENTS: 'totalComments',
+  COMMENTS_PER_REVIEW: 'commentsPerReview',
 };
 
 const TITLES = {
@@ -10,9 +11,10 @@ const TITLES = {
   timeToReview: 'Median time to review',
   totalReviews: 'Total reviews',
   totalComments: 'Total comments',
+  commentsPerReview: 'Comments / review',
 };
 
-const COLUMNS_ORDER = ['totalReviews', 'timeToReview', 'totalComments'];
+const COLUMNS_ORDER = ['totalReviews', 'timeToReview', 'totalComments', 'commentsPerReview'];
 
 const STATS_OPTIMIZATION = {
   totalReviews: 'MAX',

--- a/src/interactors/buildTable/getTableData.js
+++ b/src/interactors/buildTable/getTableData.js
@@ -30,6 +30,7 @@ const getChartsData = ({ index, contributions, displayCharts }) => {
     timeStr: addBr(generateChart(contributions.timeToReview)),
     reviewsStr: addBr(generateChart(contributions.totalReviews)),
     commentsStr: addBr(generateChart(contributions.totalComments)),
+    commentsPerReviewStr: addBr(generateChart(contributions.commentsPerReview)),
   };
 };
 
@@ -81,6 +82,7 @@ module.exports = ({
     const timeStr = addReviewsTimeLink(timeVal, disableLinks, urls.timeToReview);
     const reviewsStr = printStat(stats, 'totalReviews', noParse);
     const commentsStr = printStat(stats, 'totalComments', noParse);
+    const commentsPerReviewStr = printStat(stats, 'commentsPerReview', noParse);
 
     return {
       avatar,
@@ -88,6 +90,7 @@ module.exports = ({
       timeToReview: `${timeStr}${chartsData.timeStr}`,
       totalReviews: `${reviewsStr}${chartsData.reviewsStr}`,
       totalComments: `${commentsStr}${chartsData.commentsStr}`,
+      commentsPerReview: `${commentsPerReviewStr}${chartsData.commentsPerReviewStr}`,
     };
   };
 

--- a/src/interactors/getReviewers/calculateReviewsStats.js
+++ b/src/interactors/getReviewers/calculateReviewsStats.js
@@ -10,7 +10,7 @@ module.exports = (reviews) => {
   return {
     totalReviews,
     totalComments,
-    commentsPerReview: divide(totalComments, totalReviews),
+    commentsPerReview: Math.round(divide(totalComments, totalReviews) * 10) / 10 ,
     timeToReview: median(getProperty(reviews, 'timeToReview')),
   };
 };


### PR DESCRIPTION
Hey!
I really like the stats job and I recently started using it.

What I found missing was the stats about number of comments per pull request. When trying to achieve quality in the software, it is often more important how many comments are left per PR than just number of comments per all PRs

I am by no way a JS developer, so I am sure there would be a need to improve this further.. But I already use this branch myself in my integrations and I like the results