### PR TITLE
Fix: Last repository is missing in slack, teams message body

### DIFF
--- a/dist/index.js
+++ b/dist/index.js
@@ -2341,9 +2341,10 @@ module.exports = ({
   };
 
   const buildFullList = (sources) => {
-    const last = sources.pop();
+    const firsts = sources.slice(0, sources.length - 1);
+    const last = sources[sources.length - 1];
     return t('table.sources.fullList', {
-      firsts: sources.map(buildLink).join(t('table.sources.separator')),
+      firsts: firsts.map(buildLink).join(t('table.sources.separator')),
       last: buildLink(last),
     });
   };

--- a/src/utils/__test__/buildSources.test.js
+++ b/src/utils/__test__/buildSources.test.js
@@ -45,11 +45,13 @@ describe('Interactors | .sources', () => {
 
   describe('when sending 3 repos', () => {
     const repos = [REPO1, REPO2, REPO3];
+    const expectedLength = repos.length;
     const expected = `${linkRepo(REPO1)}, ${linkRepo(REPO2)} and ${linkRepo(REPO3)}`;
 
     it('builds the message in singular', () => {
       const response = buildSources({ buildGithubLink, repos });
       expect(response).toEqual(expected);
+      expect(repos.length).toEqual(expectedLength);
     });
   });
 

--- a/src/utils/buildSources.js
+++ b/src/utils/buildSources.js
@@ -23,9 +23,10 @@ module.exports = ({
   };
 
   const buildFullList = (sources) => {
-    const last = sources.pop();
+    const firsts = sources.slice(0, sources.length - 1);
+    const last = sources[sources.length - 1];
     return t('table.sources.fullList', {
-      firsts: sources.map(buildLink).join(t('table.sources.separator')),
+      firsts: firsts.map(buildLink).join(t('table.sources.separator')),
       last: buildLink(last),
     });
   };


### PR DESCRIPTION
Fix: #59

Use `slice` instead of `pop` to keep original source `repos` unchagned.