### PR TITLE
GetPulls iterate all pages when there's a null author PR

### DIFF
--- a/src/interactors/__tests__/getPulls.test.js
+++ b/src/interactors/__tests__/getPulls.test.js
@@ -95,5 +95,26 @@ describe('Interactors | .getPulls', () => {
         }),
       );
     });
+
+
+    it('calls fetcher the expected amount of times when there are null pr author items', async () => {
+      const itemsPerPage = 3;
+
+      const nullAuthorResponse = buildResponse(itemsPerPage)
+      nullAuthorResponse.search.edges.node.author = null
+
+      fetchPullRequests
+        .mockReturnValueOnce(nullAuthorResponse)
+        .mockReturnValueOnce(buildResponse(1));
+
+      await getPulls({ ...input, itemsPerPage });
+      expect(parsePullRequest).toBeCalledTimes(itemsPerPage + 1);
+      expect(fetchPullRequests).toBeCalledTimes(2);
+      expect(fetchPullRequests).toHaveBeenLastCalledWith(
+        expect.objectContaining({
+          after: 'CURSOR',
+        }),
+      );
+    });
   });
 });

--- a/src/interactors/__tests__/getPulls.test.js
+++ b/src/interactors/__tests__/getPulls.test.js
@@ -100,8 +100,8 @@ describe('Interactors | .getPulls', () => {
     it('calls fetcher the expected amount of times when there are null pr author items', async () => {
       const itemsPerPage = 3;
 
-      const nullAuthorResponse = buildResponse(itemsPerPage)
-      nullAuthorResponse.search.edges[0].node.author = null
+      const nullAuthorResponse = buildResponse(itemsPerPage);
+      nullAuthorResponse.search.edges[0].node.author = null;
 
       fetchPullRequests
         .mockReturnValueOnce(nullAuthorResponse)

--- a/src/interactors/__tests__/getPulls.test.js
+++ b/src/interactors/__tests__/getPulls.test.js
@@ -101,7 +101,7 @@ describe('Interactors | .getPulls', () => {
       const itemsPerPage = 3;
 
       const nullAuthorResponse = buildResponse(itemsPerPage)
-      nullAuthorResponse.search.edges.node.author = null
+      nullAuthorResponse.search.edges[0].node.author = null
 
       fetchPullRequests
         .mockReturnValueOnce(nullAuthorResponse)

--- a/src/interactors/getPulls.js
+++ b/src/interactors/getPulls.js
@@ -20,7 +20,7 @@ const getPullRequests = async (params) => {
     .filter(filterNullAuthor)
     .map(parsePullRequest);
 
-  if (results.length < limit) return results;
+  if (data.search.edges.length < limit) return results;
 
   const last = results[results.length - 1].cursor;
   return results.concat(await getPullRequests({ ...params, after: last }));


### PR DESCRIPTION
I noticed this while reading code.