### PR TITLE
Add stats as a github step output

### DIFF
--- a/action.yml
+++ b/action.yml
@@ -55,6 +55,9 @@ inputs:
   webhook:
     description: 'A webhook URL to post resulting stats.'
     required: false
+outputs:
+  results:
+    description: 'The resulting stats stored as a step output variable'
 runs:
   using: 'node16'
   main: 'dist/index.js'

--- a/dist/index.js
+++ b/dist/index.js
@@ -14317,6 +14317,7 @@ const run = async (params) => {
   await postSlackMessage({ ...whParams, pullRequest });
   await postTeamsMessage({ ...whParams, pullRequest });
   await postSummary({ core, content });
+  await core.setOutput('results', content);
 
   if (!pullRequestId) return;
   await postComment({

--- a/src/execute.js
+++ b/src/execute.js
@@ -73,6 +73,7 @@ const run = async (params) => {
   await postSlackMessage({ ...whParams, pullRequest });
   await postTeamsMessage({ ...whParams, pullRequest });
   await postSummary({ core, content });
+  await core.setOutput('results', content);
 
   if (!pullRequestId) return;
   await postComment({


### PR DESCRIPTION
This will give users the ability to manipulate the outcome of a run themselves and connect to arbitrary output sources. I tried this myself and was able to send a reasonably well formatted email with minimal work (see https://github.com/damccorm/playground/blob/main/.github/workflows/pr-stats.yml for my example).

Fixes #72