### PR TITLE
fix: abort when no review entries are found for period

### DIFF
--- a/src/__tests__/execute.test.js
+++ b/src/__tests__/execute.test.js
@@ -141,6 +141,14 @@ describe('execute', () => {
     expect(github.getOctokit).toBeCalledWith(inputs.personalToken, { baseUrl: githubUrl });
   });
 
+  it('aborts execution when no entries are found', async () => {
+    getEntries.mockResolvedValueOnce([]);
+    const results = await execute(inputs);
+    expect(results).toBeNull();
+    expect(getEntries).toBeCalled();
+    expect(publish).not.toBeCalled();
+  });
+
   describe('Sponsorship', () => {
     it('checks if the user is a sponsor', async () => {
       checkSponsorship.mockResolvedValueOnce(true);

--- a/src/execute.js
+++ b/src/execute.js
@@ -40,6 +40,11 @@ const run = async ({ inputs, octokit }) => {
   });
   core.debug(`Analyzed entries: ${entries.length}`);
 
+  if (entries.length === 0) {
+    core.info('No reviews found for the specified period.');
+    return null;
+  }
+
   await publish({
     core,
     octokit,


### PR DESCRIPTION
Error: 
<img width="494" height="142" alt="image" src="https://github.com/user-attachments/assets/5f244743-8225-4717-9a13-ea3990cc0a53" />

This PR makes sure the process is aborted when no entries are found. Added a test that verifies the behavior.
